### PR TITLE
Update la7.py

### DIFF
--- a/channels/la7.py
+++ b/channels/la7.py
@@ -156,6 +156,12 @@ def findvideos(item):
         lic_url='%s|%s|R{SSM}|'%(license_url, preLic)
         item.drm = DRM
         item.license = lic_url
+    elif url=='':
+        match = support.match(data, patron=r'''["]?m3u8["]?\s*:\s*["']([^"']+)["']''').match
+        if match:
+            url = "https://awsvodpkg.iltrovatore.it/local/dash/" + \
+                     match.split("http://la7-vh.akamaihd.net/i")[1].split("csmil/master.m3u8")[0] + \
+                     "urlset/manifest.mpd";
     else:
         match = support.match(data, patron='/content/entry/data/(.*?).mp4').match
         if match:


### PR DESCRIPTION
nel caso il manifest mpd non sia disponibile e' possibile fare il fallback all'm3u8 (720p) invece che all'mp4 (480p)